### PR TITLE
Rename 'index' to 'main' in package.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "type": "git",
     "url": "monken/node-pbac"
   },
-  "index": "bpac",
+  "main": "pbac.js",
   "author": "Moritz Onken <onken@netcubed.de>",
   "license": "MIT"
 }


### PR DESCRIPTION
Requiring this modules is currently broken, this is a small fix for this. 
